### PR TITLE
Change the package.json license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "custom-attributes.js",
   "repository": "git@github.com:Mariusthvdb/custom-attributes.git",
   "author": "Mariusthvdb",
-  "license": "Apache-2.0",
+  "license": "GPL-3.0",
   "scripts": {
     "build": "rollup --config rollup.config.js --bundleConfigAsCjs",
     "test:ts": "tsc --noEmit",


### PR DESCRIPTION
The License of the repo is the [GNU General Public License v3.0](https://github.com/Mariusthvdb/custom-attributes/blob/main/LICENSE), but `package.json` was set to [Apache License 2.0](https://spdx.org/licenses/Apache-2.0.html), this pull request changes the `package.json` license to match the license of the repo.